### PR TITLE
Added support for VS2013 and VS2015

### DIFF
--- a/NuGetReferences/source.extension.vsixmanifest
+++ b/NuGetReferences/source.extension.vsixmanifest
@@ -12,11 +12,11 @@
         <PreviewImage>Resources\Preview.png</PreviewImage>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="11.0" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="12.0" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="14.0" />
     </Installation>
     <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.MPF" DisplayName="Visual Studio MPF" Version="[11.0,)" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage"


### PR DESCRIPTION
I've removed the default dependencies because they interfere with VS2015 and should never have been in the VSIX project template to begin with.